### PR TITLE
change to be inline with documentation

### DIFF
--- a/pandaharvester/harvesterbody/master.py
+++ b/pandaharvester/harvesterbody/master.py
@@ -145,8 +145,8 @@ if __name__ == "__main__":
                         help='use single mode')
 
     options = parser.parse_args()
-    uid = pwd.getpwnam(harvester_config.master.uname).pw_uid
-    gid = grp.getgrnam(harvester_config.master.gname).gr_gid
+    uid = pwd.getpwuid(harvester_config.master.uname).pw_uid
+    gid = grp.getgrgid(harvester_config.master.gname).gr_gid
     timeNow = datetime.datetime.utcnow()
     print "{0} Master: INFO    start".format(str(timeNow))
 


### PR DESCRIPTION
panda_harvester.cfg configuration documentation states:

  master.uname	User ID of the daemon process
master.gname	Group ID of the daemon process
if we are using uid and gid then must change to use uid/gid versions