### PR TITLE
protection against existing symlinks

### DIFF
--- a/pandaharvester/harvestermessenger/shared_file_messenger.py
+++ b/pandaharvester/harvestermessenger/shared_file_messenger.py
@@ -261,6 +261,10 @@ class SharedFileMessenger(PluginBase):
                 for inLFN, inFile in inFiles.iteritems():
                     dstPath = os.path.join(workspec.get_access_point(), inLFN)
                     if inFile['path'] != dstPath:
+                        # test if symlink exists if so remove it
+                        if os.path.exists(dstPath) :
+                            os.unlink(dstPath)
+                            tmpLog.debug("removing existing symlink %s" % dstPath)
                         os.symlink(inFile['path'], dstPath)
             except:
                 core_utils.dump_error_message(tmpLog)


### PR DESCRIPTION
make change to shared_file_messenger code to remove input file symlink if exists before creating the new one