### PR TITLE
fix file name typo - add more debug statements to logger

### DIFF
--- a/pandaharvester/harvestermonitor/cobalt_monitor.py
+++ b/pandaharvester/harvestermonitor/cobalt_monitor.py
@@ -88,11 +88,15 @@ class CobaltMonitor (PluginBase):
                 # look for jobReport.json file 
                 jsonFilePath = os.path.join(workSpec.accessPoint,"jobReport.json")
                 if os.path.exists(jsonFilePath):
+                    tmpLog.debug('found jobReport.json file : {0}'.format(jsonFilePath))
                     try:
-                        with open(readJsonPath) as jsonFile:
+                        with open(jsonFilePath) as jsonFile:
                             loadDict = json.load(jsonFile)
+                        #tmpLog.debug('loaded jobReport dict : {0}'.format(str(loadDict)))
+                        tmpLog.debug('loaded jobReport dict')
                         if 'exitCode' in loadDict :
-                            if loadDict['exitCode'] == 0:
+                            tmpLog.debug('loadDict[exitCode] = {0}'.format(str(loadDict['exitCode'])))
+                            if int(loadDict['exitCode']) == 0:
                                 newStatus = WorkSpec.ST_finished
                             else :
                                 newStatus = WorkSpec.ST_failed
@@ -109,11 +113,14 @@ class CobaltMonitor (PluginBase):
                     except:
                         # failed
                         errStr = 'failed to load existing jobReport.json'
+                        newStatus = WorkSpec.ST_failed
                         tmpLog.error(errStr)
                         retList.append((newStatus, errStr))
                         continue
                 else:
-                    errStr = 'qstat stdout: ' + stdOut + ' stat stderr: ' + stdErr + ' '
+                    tmpLog.debug('Did not find jobReport.json file : {0}'.format(jsonFilePath))
+                    errStr = 'qstat {0} return code non zero and jobReport.json file not found '.format(workSpec.batchID)
+                    newStatus =  WorkSpec.ST_failed
                     tmpLog.error(errStr)
                     retList.append((newStatus, errStr))
         return True, retList


### PR DESCRIPTION
fix mistake in cobalt_monitor.py and add additional information to the the debug log