### PR TITLE
catch qsub exiting state and avoid rucio with no files

### DIFF
--- a/pandaharvester/harvestermonitor/cobalt_monitor.py
+++ b/pandaharvester/harvestermonitor/cobalt_monitor.py
@@ -78,6 +78,8 @@ class CobaltMonitor (PluginBase):
                        newStatus = WorkSpec.ST_running
                     elif 'killing' in state:
                        newStatus = WorkSpec.ST_failed
+                    elif 'exiting' in state:
+                       newStatus = WorkSpec.ST_running
                     else:
                        raise Exception('failed to parse job state "%s" qstat stdout: %s\n stderr: %s' % (state,stdOut,stdErr))
                 

--- a/pandaharvester/harvesterpreparator/pilotmover_preparator.py
+++ b/pandaharvester/harvesterpreparator/pilotmover_preparator.py
@@ -56,15 +56,17 @@ class PilotmoverPreparator(PluginBase):
                           'destination': dstpath})
         tmpLog.debug('files[] {0}'.format(files))
         data_client = data.StageInClient(site=jobspec.computingSite)
-        result = data_client.transfer(files)
-        tmpLog.debug('pilot.api data.StageInClient.transfer(files) result: {0}'.format(result))
-        # loop over each file check result all must be true for entire result to be true
         allChecked = True
         ErrMsg = 'These files failed to download : '
-        for answer in result:
-            if answer['errno'] != 0:
-                allChecked = False
-                ErrMsg = ErrMsg + (" %s " % answer['name'])
+        if len(files) > 0:
+            result = data_client.transfer(files)
+            tmpLog.debug('pilot.api data.StageInClient.transfer(files) result: {0}'.format(result))
+        
+            # loop over each file check result all must be true for entire result to be true
+            for answer in result:
+                if answer['errno'] != 0:
+                    allChecked = False
+                    ErrMsg = ErrMsg + (" %s " % answer['name'])
         # return
         tmpLog.debug('stop')
         if allChecked:


### PR DESCRIPTION
Updated cobalt monitor to address 'exiting' state and keep job in 'running' state. Updated pilotmover such that it does not try to call rucio stage out with an empty list of files.