### PR TITLE
adding usrmax_hold to cobalt monitor

### DIFF
--- a/pandaharvester/harvestermonitor/cobalt_monitor.py
+++ b/pandaharvester/harvestermonitor/cobalt_monitor.py
@@ -81,6 +81,8 @@ class CobaltMonitor (PluginBase):
                        newStatus = WorkSpec.ST_failed
                     elif 'exiting' in state:
                        newStatus = WorkSpec.ST_running
+                    elif 'maxrun_hold' in state:
+                       newStatus = WorkSpec.ST_submitted
                     else:
                        raise Exception('failed to parse job state "%s" qstat stdout: %s\n stderr: %s' % (state,stdOut,stdErr))
                 


### PR DESCRIPTION
Making cobalt monitor aware of new cobalt state. This state occurs when the user has too many jobs in the running state.