### PR TITLE
temporary fix to handle errors

### DIFF
--- a/pandaharvester/harvestermessenger/shared_file_messenger.py
+++ b/pandaharvester/harvestermessenger/shared_file_messenger.py
@@ -496,14 +496,12 @@ class SharedFileMessenger(PluginBase):
                     logFilePath += '.{0}'.format(workspec.workerID)
                 tmpLog.debug('making {0}'.format(logFilePath))
                 with tarfile.open(logFilePath, "w:gz") as tmpTarFile:
-                    for tmpFile in os.listdir(accessPoint):
-                        if not self.filter_log_tgz(tmpFile):
-                            continue
-                        tmpFullPath = os.path.join(accessPoint, tmpFile)
-                        if not os.path.isfile(tmpFullPath):
-                            continue
-                        tmpRelPath = re.sub(accessPoint+'/*', '', tmpFullPath)
-                        tmpTarFile.add(tmpFullPath, arcname=tmpRelPath)
+                    for path,dirs,files in os.walk(accessPoint):
+                        for filename in files:
+                           if self.filter_log_tgz(filename):
+                              tmpFullPath = os.path.join(path,filename)
+                              tmpRelPath = re.sub(accessPoint+'/*','',tmpFullPath)
+                              tmpTarFile.add(tmpFullPath, arcname=tmpRelPath)
                 # make json to stage-out the log file
                 fileDict = dict()
                 fileDict[jobSpec.PandaID] = []

--- a/pandaharvester/harvesterpreparator/go_preparator.py
+++ b/pandaharvester/harvesterpreparator/go_preparator.py
@@ -197,19 +197,8 @@ class GoPreparator(PluginBase):
             # if no files to transfer return True
             return True, 'No files to transfer'
         except:
-<<<<<<< HEAD
-            errmsg = globus_utils.handle_globus_exception(tmpLog)
-            
-            if 'TooManyPendingJobs' in errmsg:
-               # return None so transfer will be retried later
-               tmpLog.info('to many transfers, will try again later')
-               return None,{}
-
-            return False, {}
-=======
             errStat,errMsg = globus_utils.handle_globus_exception(tmpLog)
             return errStat, {}
->>>>>>> upstream/master
 
 
     # make label for transfer task

--- a/pandaharvester/harvesterpreparator/go_preparator.py
+++ b/pandaharvester/harvesterpreparator/go_preparator.py
@@ -62,7 +62,7 @@ class GoPreparator(PluginBase):
         if label not in transferTasks:
             errStr = 'transfer task is missing'
             tmpLog.error(errStr)
-            return False, errStr
+            return None, errStr
         # succeeded
         if transferTasks[label]['status'] == 'SUCCEEDED':
             transferID = transferTasks[label]['task_id'] 
@@ -189,7 +189,13 @@ class GoPreparator(PluginBase):
             # if no files to transfer return True
             return True, 'No files to transfer'
         except:
-            globus_utils.handle_globus_exception(tmpLog)
+            errmsg = globus_utils.handle_globus_exception(tmpLog)
+            
+            if 'TooManyPendingJobs' in errmsg:
+               # return None so transfer will be retried later
+               tmpLog.info('to many transfers, will try again later')
+               return None,{}
+
             return False, {}
 
     # get transfer tasks

--- a/pandaharvester/harvestersubmitter/cobalt_submitter.py
+++ b/pandaharvester/harvestersubmitter/cobalt_submitter.py
@@ -77,7 +77,8 @@ class CobaltSubmitter(PluginBase):
     def make_batch_script(self, workspec):
         tmpFile = tempfile.NamedTemporaryFile(delete=False, suffix='_submit.sh', dir=workspec.get_access_point())
         tmpFile.write(self.template.format(nNode=workspec.nCore / self.nCorePerNode,
-                                           accessPoint=workspec.accessPoint)
+                                           accessPoint=workspec.accessPoint,
+                                           workerID=workspec.workerID)
                       )
         tmpFile.close()
 


### PR DESCRIPTION
I changed the go_preparator so that it returns None instead of False when it receives a 'transfer task is missing' error. There is a time lag between transfer task creation and being able to see the task via the command line tools. Therefore, Harvester was returning transfer errors because it was checking for the tasks too quickly after creating them. This is a temporary fix. A more robust fix would be to have a time stamp of when the transfer was created, then return None if 'transfer task is missing' is received within some time limit of the transfer task creation. After that time limit a real error should be thrown and False should be returned. I wasn't sure how to implement this. In principle, this same change needs to be made to the go_stager as well.

I also updated the exception handling to intercept 'TooManyPendingJobs' messages and return None so transfers will be retried instead of failed. This also needs to be done for the go_stager.