### PR TITLE
Fixed logging object error while interacting with SAGA

### DIFF
--- a/pandaharvester/harvesterbody/master.py
+++ b/pandaharvester/harvesterbody/master.py
@@ -256,10 +256,9 @@ def main(daemon_mode=True):
                 for handler in loggerObj.handlers:
                     if hasattr(handler, 'stream'):
                         files_preserve.append(handler.stream)
-        sys.stderr = StdErrWrapper()
         # make daemon context
         dc = daemon.DaemonContext(stdout=sys.stdout,
-                                  stderr=sys.stderr,
+                                  stderr=StdErrWrapper(),
                                   uid=uid,
                                   gid=gid,
                                   umask=umask,


### PR DESCRIPTION
There was an error with SAGA submitter because in master.py the global sys.stderr was replaced by a wrapper, but SAGA was checking whether it was a stream and it caused exceptions.
I hope it gives no impact on other submitters.