### PR TITLE
shared_file_messenger now recursively adds log files in accessPoint f…  

### DIFF
--- a/pandaharvester/harvestermessenger/shared_file_messenger.py
+++ b/pandaharvester/harvestermessenger/shared_file_messenger.py
@@ -496,14 +496,12 @@ class SharedFileMessenger(PluginBase):
                     logFilePath += '.{0}'.format(workspec.workerID)
                 tmpLog.debug('making {0}'.format(logFilePath))
                 with tarfile.open(logFilePath, "w:gz") as tmpTarFile:
-                    for tmpFile in os.listdir(accessPoint):
-                        if not self.filter_log_tgz(tmpFile):
-                            continue
-                        tmpFullPath = os.path.join(accessPoint, tmpFile)
-                        if not os.path.isfile(tmpFullPath):
-                            continue
-                        tmpRelPath = re.sub(accessPoint+'/*', '', tmpFullPath)
-                        tmpTarFile.add(tmpFullPath, arcname=tmpRelPath)
+                    for path,dirs,files in os.walk(accessPoint):
+                        for filename in files:
+                           if self.filter_log_tgz(filename):
+                              tmpFullPath = os.path.join(path,filename)
+                              tmpRelPath = re.sub(accessPoint+'/*','',tmpFullPath)
+                              tmpTarFile.add(tmpFullPath, arcname=tmpRelPath)
                 # make json to stage-out the log file
                 fileDict = dict()
                 fileDict[jobSpec.PandaID] = []

--- a/pandaharvester/harvesterpreparator/go_preparator.py
+++ b/pandaharvester/harvesterpreparator/go_preparator.py
@@ -79,7 +79,7 @@ class GoPreparator(PluginBase):
         if label not in transferTasks:
             errStr = 'transfer task is missing'
             tmpLog.error(errStr)
-            return None, errStr
+            return False, errStr
         # succeeded
         if transferTasks[label]['status'] == 'SUCCEEDED':
             transferID = transferTasks[label]['task_id'] 

--- a/pandaharvester/harvesterpreparator/go_preparator.py
+++ b/pandaharvester/harvesterpreparator/go_preparator.py
@@ -197,19 +197,8 @@ class GoPreparator(PluginBase):
             # if no files to transfer return True
             return True, 'No files to transfer'
         except:
-<<<<<<< HEAD
-            errmsg = globus_utils.handle_globus_exception(tmpLog)
-            
-            if 'TooManyPendingJobs' in errmsg:
-               # return None so transfer will be retried later
-               tmpLog.info('to many transfers, will try again later')
-               return None,{}
-
-            return False, {}
-=======
             errStat,errMsg = globus_utils.handle_globus_exception(tmpLog)
             return errStat, {}
->>>>>>> upstream/master
 
 
     # make label for transfer task

--- a/pandaharvester/harvesterpreparator/go_preparator.py
+++ b/pandaharvester/harvesterpreparator/go_preparator.py
@@ -62,7 +62,7 @@ class GoPreparator(PluginBase):
         if label not in transferTasks:
             errStr = 'transfer task is missing'
             tmpLog.error(errStr)
-            return False, errStr
+            return None, errStr
         # succeeded
         if transferTasks[label]['status'] == 'SUCCEEDED':
             transferID = transferTasks[label]['task_id'] 
@@ -189,7 +189,13 @@ class GoPreparator(PluginBase):
             # if no files to transfer return True
             return True, 'No files to transfer'
         except:
-            globus_utils.handle_globus_exception(tmpLog)
+            errmsg = globus_utils.handle_globus_exception(tmpLog)
+            
+            if 'TooManyPendingJobs' in errmsg:
+               # return None so transfer will be retried later
+               tmpLog.info('to many transfers, will try again later')
+               return None,{}
+
             return False, {}
 
     # get transfer tasks

--- a/pandaharvester/harvestersubmitter/cobalt_submitter.py
+++ b/pandaharvester/harvestersubmitter/cobalt_submitter.py
@@ -77,7 +77,8 @@ class CobaltSubmitter(PluginBase):
     def make_batch_script(self, workspec):
         tmpFile = tempfile.NamedTemporaryFile(delete=False, suffix='_submit.sh', dir=workspec.get_access_point())
         tmpFile.write(self.template.format(nNode=workspec.nCore / self.nCorePerNode,
-                                           accessPoint=workspec.accessPoint)
+                                           accessPoint=workspec.accessPoint,
+                                           workerID=workspec.workerID)
                       )
         tmpFile.close()
 


### PR DESCRIPTION
shared_file_messenger now recursively adds log files in accessPoint folder, 
cobalt_submitter: added the worker ID to the template formatter because I added jobnames to cobalt jobs so you can query the scheduler and see the harvester worker ID, thereby easily finding the worker directory 