### PR TITLE
Improve CE weight. Reduce condor job ads to query

### DIFF
--- a/pandaharvester/commit_timestamp.py
+++ b/pandaharvester/commit_timestamp.py
@@ -1,1 +1,1 @@
-timestamp = "04-10-2018 14:28:24 on contrib_cern (by fahui)"
+timestamp = "05-10-2018 18:26:48 on contrib_cern (by fahui)"

--- a/pandaharvester/harvestermonitor/htcondor_monitor.py
+++ b/pandaharvester/harvestermonitor/htcondor_monitor.py
@@ -51,6 +51,14 @@ CONDOR_JOB_STATUS_MAP = {
     }
 
 
+## List of job ads required
+CONDOR_JOB_ADS_LIST = [
+    'ClusterId', 'ProcId', 'JobStatus',
+    'JobStartDate', 'EnteredCurrentStatus', 'ExitCode',
+    'HoldReason', 'LastHoldReason', 'RemoveReason',
+]
+
+
 ## generate condor job id with schedd host from workspec
 def condor_job_id_from_workspec(workspec):
     return '{0}#{1}'.format(workspec.submissionHost, workspec.batchID)
@@ -202,7 +210,7 @@ class CondorJobQuery(six.with_metaclass(SingletonWithID, object)):
             requirements = 'member(ClusterID, {{{0}}})'.format(batchIDs_str)
             tmpLog.debug('Query method: {0} ; requirements: "{1}"'.format(query_method.__name__, requirements))
             ## Query
-            jobs_iter = query_method(requirements=requirements, projection=[])
+            jobs_iter = query_method(requirements=requirements, projection=CONDOR_JOB_ADS_LIST)
             for job in jobs_iter:
                 job_ads_dict = dict(job)
                 batchid = str(job_ads_dict['ClusterId'])

--- a/pandaharvester/harvestersubmitter/htcondor_submitter.py
+++ b/pandaharvester/harvestersubmitter/htcondor_submitter.py
@@ -37,15 +37,26 @@ def _get_ce_weight_dict(ce_endpoint_list=[], queue_status_dict={}, worker_ce_sta
             return float(1)
         N = float(n_ce)
         Q = float(queue_status_dict['nQueueLimitWorker'])
-        R = float(queue_status_dict['maxWorkers'])
+        # R = float(queue_status_dict['maxWorkers'])
         q = float(worker_ce_stats_dict[_ce_endpoint]['submitted'])
         r = float(worker_ce_stats_dict[_ce_endpoint]['running'])
+        q_avg = sum(( float(worker_ce_stats_dict[_k]['submitted']) for _k in worker_ce_stats_dict )) / N
+        # r_avg = sum(( float(worker_ce_stats_dict[_k]['running']) for _k in worker_ce_stats_dict )) / N
         if ( _ce_endpoint in worker_ce_stats_dict and q > Q ):
             return float(0)
         else:
-            ret = ( 1 if (N*q <= Q) else sqrt((1 - q/Q)*N/(N - 1)) )
+            # Base weight by total queuing ratio
+            if (N*q <= Q):
+                ret = 1
+            else:
+                ret = sqrt((1 - q/Q)*N/(N - 1))
             if r == 0:
+                # Penalty for dead CE (no running worker)
                 ret = ret / (1 + log1p(q)**2)
+            else:
+                # Weight by individual queuing ratio compared with average
+                _weight = max(1 - ((q - q_avg)/sqrt(1 + q_avg * Q)), 0)
+                ret = ret * _weight
             return ret
     init_weight_iterator = map(_get_init_weight, ce_endpoint_list)
     sum_of_weight = sum(list(init_weight_iterator))


### PR DESCRIPTION
Number of submitted workers are now considered when computing CE weight. E.g.:

```
worker_ce_stats_dict: {'ce01.tier2.hep.manchester.ac.uk:2811': {'running': 281L, 'submitted': 203L, 'to_submit': 0}, 'ce02.tier2.hep.manchester.ac.uk:2811': {'running': 313L, 'submitted': 442L, 'to_submit': 0}}
ce_weight_dict: {u'ce01.tier2.hep.manchester.ac.uk:2811': 12, u'ce02.tier2.hep.manchester.ac.uk:2811': 7}
```

Specifying condor job ads reduces network out by 70% on schedd node (and 1~2% CPU down). Not sure about how much help to reduce timeout so far