### PR TITLE
RT mapper default cores and memory. K8S handle None value worker requirements

### DIFF
--- a/pandaharvester/commit_timestamp.py
+++ b/pandaharvester/commit_timestamp.py
@@ -1,1 +1,1 @@
-timestamp = "07-02-2019 05:49:11 on contrib_cern (by fahui)"
+timestamp = "07-02-2019 06:15:09 on contrib_cern (by fahui)"

--- a/pandaharvester/commit_timestamp.py
+++ b/pandaharvester/commit_timestamp.py
@@ -1,1 +1,1 @@
-timestamp = "06-02-2019 09:05:34 on contrib_cern (by fahui)"
+timestamp = "07-02-2019 05:49:11 on contrib_cern (by fahui)"

--- a/pandaharvester/harvestercore/resource_type_mapper.py
+++ b/pandaharvester/harvestercore/resource_type_mapper.py
@@ -58,8 +58,8 @@ class ResourceTypeMapper(object):
         """
         Calculates worker requirements (cores and memory) to request in pilot streaming mode/unified pull queue
         """
-        worker_cores = None
-        worker_memory = None
+        worker_cores = 1
+        worker_memory = 1
 
         self.load_data()
         try:

--- a/pandaharvester/harvestermisc/k8s_utils.py
+++ b/pandaharvester/harvestermisc/k8s_utils.py
@@ -50,13 +50,14 @@ class k8s_Client(six.with_metaclass(SingletonWithID, object)):
         container_env.setdefault('resources', {})
 
         # note that predefined values in the yaml template will NOT be overwritten
-        container_env['resources'].setdefault('limits', {
-            'memory': str(work_spec.minRamCount) + 'M',
-            'cpu': str(work_spec.nCore)})
+        if work_spec.nCore and work_spec.minRamCount:
+            container_env['resources'].setdefault('limits', {
+                'memory': str(work_spec.minRamCount) + 'M',
+                'cpu': str(work_spec.nCore)})
 
-        container_env['resources'].setdefault('requests', {
-            'memory': str(work_spec.minRamCount*memoryadjustratio/100.0) + 'M',
-            'cpu': str(work_spec.nCore*cpuadjustratio/100.0)})
+            container_env['resources'].setdefault('requests', {
+                'memory': str(work_spec.minRamCount*memoryadjustratio/100.0) + 'M',
+                'cpu': str(work_spec.nCore*cpuadjustratio/100.0)})
 
         container_env.setdefault('env', [])
 


### PR DESCRIPTION
Not sure if this makes sense.
But there was possibility that workspec.nCore and workspec.minRamCount are None for UPS queue.
And this actually happened on aipanda083 K8S queue, e.g.

```
*************************** 1. row ***************************
           workerID: 955351
            batchID: NULL
            mapType: NoJob
          queueName: NULL
             status: missed
             hasJob: 0
         workParams: {"lastCheckAt": 1549515694.8757567}
     workAttributes: {"pilotErrorCode": 1110, "pilotErrorDiag": "failed to submit a workerID=955351 with Failed to create a JOB; unsupported operand type(s) for *: 'NoneType' and 'int'"}
eventsRequestParams: null
      eventsRequest: NULL
      computingSite: CERN-EXTENSION_K8S_HARVESTER
       creationTime: 2019-02-07 05:01:34
         submitTime: 2019-02-07 05:01:34
          startTime: NULL
            endTime: 2019-02-07 05:01:35
              nCore: NULL
           walltime: NULL
        accessPoint: /data/atlpan/harvester_wdirs/test_aipanda083/53/51/955351
   modificationTime: 2019-02-07 05:01:34
         lastUpdate: NULL
      eventFeedTime: NULL
           lockedBy: NULL
      postProcessed: NULL
             nodeID: NULL
        minRamCount: NULL
       maxDiskCount: 50000
        maxWalltime: 345600
           killTime: NULL
   computingElement: NULL
      nJobsToReFill: NULL
   logFilesToUpload: null
       resourceType: MCORE
     nativeExitCode: NULL
       nativeStatus: NULL
        diagMessage: Failed to create a JOB; unsupported operand type(s) for *: 'NoneType' and 'int'
              nJobs: NULL
     submissionHost: NULL
           configID: 35208
          syncLevel: 1
          checkTime: 2019-02-07 05:01:34
        ioIntensity: NULL
      harvesterHost: aipanda083.cern.ch
          pilotType: PR
      eventFeedLock: NULL
```

I guess currently we like to trust workspec.nCore and other requirements from worker_maker (including rt mapper) more than to handle None-value exception in each submitter plugin.