### PR TITLE
Activated jobs

### DIFF
--- a/pandaharvester/harvesterbody/cacher.py
+++ b/pandaharvester/harvesterbody/cacher.py
@@ -131,7 +131,9 @@ class Cacher(AgentBase):
                 core_utils.dump_error_message(tmp_log)
         elif info_url.startswith('panda_server:'):
             try:
-                retVal, outStr = self.communicator.get_resource_types()
+                method_name = info_url.split(':')[-1]
+                method_function = getattr(self.communicator, method_name)
+                retVal, outStr = method_function()
                 if not retVal:
                     tmp_log.error(outStr)
             except Exception:

--- a/pandaharvester/harvesterbody/worker_adjuster.py
+++ b/pandaharvester/harvesterbody/worker_adjuster.py
@@ -39,6 +39,13 @@ class WorkerAdjuster(object):
             else:
                 queueStat = queueStat.data
 
+            # get job statistics
+            job_stats = self.dbProxy.get_cache("job_statistics.json", None)
+            if job_stats is None:
+                job_stats = dict()
+            else:
+                job_stats = job_stats.data
+
             # define num of new workers
             for queueName in static_num_workers:
                 # get queue
@@ -135,6 +142,13 @@ class WorkerAdjuster(object):
                                 maxQueuedWorkers = min(maxQueuedWorkers_slave, maxQueuedWorkers)
                             else:
                                 maxQueuedWorkers = maxQueuedWorkers_slave
+                        else:
+                            # limit the queue to the number of activated jobs to avoid empty pilots
+                            try:
+                                n_activated = job_stats[queueName]['activated']
+                                maxQueuedWorkers = n_activated
+                            except KeyError:
+                                maxQueuedWorkers = 1
 
                         if maxQueuedWorkers is None:  # no value found, use default value
                             maxQueuedWorkers = 1

--- a/pandaharvester/harvesterbody/worker_adjuster.py
+++ b/pandaharvester/harvesterbody/worker_adjuster.py
@@ -146,7 +146,9 @@ class WorkerAdjuster(object):
                             # limit the queue to the number of activated jobs to avoid empty pilots
                             try:
                                 n_activated = job_stats[queueName]['activated']
-                                maxQueuedWorkers = n_activated
+                                maxQueuedWorkers = min(n_activated, maxQueuedWorkers)
+                                tmpLog.debug('limiting maxQueuedWorkers to min(n_activated={0}, queue_limit={1})'.
+                                             format(n_activated, maxQueuedWorkers))
                             except KeyError:
                                 maxQueuedWorkers = 1
 

--- a/pandaharvester/harvestercommunicator/panda_communicator.py
+++ b/pandaharvester/harvestercommunicator/panda_communicator.py
@@ -10,6 +10,7 @@ except Exception:
     pass
 import sys
 import json
+import pickle
 import zlib
 import uuid
 import inspect
@@ -441,6 +442,25 @@ class PandaCommunicator(BaseCommunicator):
 
         return ret_val, ret_msg
 
+    # get job statistics
+    def get_job_stats(self):
+        tmp_log = self.make_logger(method_name='get_job_stats')
+        tmp_log.debug('start')
+
+        tmp_stat, tmp_res = self.post_ssl('getJobStatisticsPerSite', {})
+        stats = {}
+        if tmp_stat is False:
+            ret_msg = 'FAILED'
+            core_utils.dump_error_message(tmp_log, tmp_res)
+        else:
+            try:
+                stats = pickle.loads(tmp_res.content)
+                ret_msg = 'OK'
+            except Exception:
+                ret_msg = 'Exception'
+                core_utils.dump_error_message(tmp_log)
+
+        return stats, ret_msg
 
     # update workers
     def update_workers(self, workspec_list):


### PR DESCRIPTION
Limit the workers on traditional pull (not UPS) queues to the amount of activated jobs, in order to avoid empty pilots