### PR TITLE
Add sdf templates without +remote_queue for BNL

### DIFF
--- a/examples/htcondor_atlas-grid-ce_pull.sdf.d/htcondor-ce-bnl.sdf
+++ b/examples/htcondor_atlas-grid-ce_pull.sdf.d/htcondor-ce-bnl.sdf
@@ -1,0 +1,35 @@
+executable = {executableFile}
+arguments = -s {computingSite} -h {pandaQueueName} -u {prodSourceLabel} -i {pilotType} {pilotResourceTypeOption} -p 25443 -w https://pandaserver.cern.ch
+initialdir = {accessPoint}
+universe = grid
+log = {logDir}/{logSubdir}/grid.$(Cluster).$(Process).log
+output = {logDir}/{logSubdir}/grid.$(Cluster).$(Process).out
+error = {logDir}/{logSubdir}/grid.$(Cluster).$(Process).err
+transfer_executable = True
+x509userproxy = {x509UserProxy}
+environment = "PANDA_JSID=harvester-{harvesterID} HARVESTER_ID={harvesterID} HARVESTER_WORKER_ID={workerID} GTAG={gtag}"
++harvesterID = "{harvesterID}"
+
+grid_resource = condor {ceHostname} {ceEndpoint}
++remote_jobuniverse = 5
++remote_ShouldTransferFiles = "YES"
++remote_WhenToTransferOutput = "ON_EXIT_OR_EVICT"
++remote_TransferOutput = ""
+#+remote_RequestCpus = {nCoreTotal}
+#+remote_RequestMemory = {requestRam}
+#+remote_RequestDisk = {requestDisk}
+#+remote_JobMaxVacateTime = {requestWalltime}
++ioIntensity = {ioIntensity}
+
++xcount = {nCoreTotal}
++maxMemory = {requestRam}
++maxWallTime = {requestWalltimeMinute}
+
+#+remote_Requirements = JobRunCount == 0
+periodic_remove = (JobStatus == 2 && (CurrentTime - EnteredCurrentStatus) > 604800)
+#+remote_PeriodicHold = ( JobStatus==1 && gridjobstatus=?=UNDEFINED && CurrentTime-EnteredCurrentStatus>3600 ) || ( (JobRunCount =!= UNDEFINED && JobRunCount > 0) ) || ( JobStatus == 2 && CurrentTime-EnteredCurrentStatus>604800 )
++remote_PeriodicRemove = (JobStatus == 5 && (CurrentTime - EnteredCurrentStatus) > 3600) || (JobStatus == 1 && globusstatus =!= 1 && (CurrentTime - EnteredCurrentStatus) > 86400)
+
++sdfPath = "{sdfPath}"
+
+queue 1

--- a/examples/htcondor_atlas-grid-ce_push.sdf.d/htcondor-ce-bnl.sdf
+++ b/examples/htcondor_atlas-grid-ce_push.sdf.d/htcondor-ce-bnl.sdf
@@ -1,0 +1,34 @@
+executable = {executableFile}
+arguments = -s {computingSite} -h {pandaQueueName} -u {prodSourceLabel} -f false -C 0 -p 25443 -w https://pandaserver.cern.ch
+initialdir = {accessPoint}
+universe = grid
+log = {logDir}/{logSubdir}/grid.$(Cluster).$(Process).log
+output = {logDir}/{logSubdir}/grid.$(Cluster).$(Process).out
+error = {logDir}/{logSubdir}/grid.$(Cluster).$(Process).err
+transfer_executable = True
+x509userproxy = {x509UserProxy}
+environment = "PANDA_JSID=harvester-{harvesterID} HARVESTER_ID={harvesterID} HARVESTER_WORKER_ID={workerID} GTAG={gtag}"
++harvesterID = "{harvesterID}"
+transfer_input_files = pandaJobData.out
+
+grid_resource = condor {ceHostname} {ceEndpoint}
++remote_jobuniverse = 5
++remote_ShouldTransferFiles = "YES"
++remote_WhenToTransferOutput = "ON_EXIT_OR_EVICT"
++remote_TransferOutput = ""
+#+remote_RequestCpus = {nCoreTotal}
+#+remote_RequestMemory = {requestRam}
+#+remote_RequestDisk = {requestDisk}
+#+remote_JobMaxVacateTime = {requestWalltime}
++ioIntensity = {ioIntensity}
+
++xcount = {nCoreTotal}
++maxMemory = {requestRam}
++maxWallTime = {requestWalltimeMinute}
+
+#+remote_Requirements = JobRunCount == 0
+periodic_remove = (JobStatus == 2 && (CurrentTime - EnteredCurrentStatus) > 604800)
+
++sdfPath = "{sdfPath}"
+
+queue 1


### PR DESCRIPTION
BNL requires an sdf without +remote_queue for their unified pilot streams. These are just clones of the htcondor-ce.sdf without this attrinbute.
Going also to submit a PR for a config template using these sdf