### PR TITLE
aCT: parse job report and report pilot failures

### DIFF
--- a/pandaharvester/harvestermonitor/act_monitor.py
+++ b/pandaharvester/harvestermonitor/act_monitor.py
@@ -1,9 +1,16 @@
+import os
+import json
+
 from pandaharvester.harvestercore import core_utils
 from pandaharvester.harvestercore.work_spec import WorkSpec
 from pandaharvester.harvestercore.plugin_base import PluginBase
+from pandaharvester.harvesterconfig import harvester_config
 
 from act.common.aCTConfig import aCTConfigARC
 from act.atlas.aCTDBPanda import aCTDBPanda
+
+# json for job report
+jsonJobReport = harvester_config.payload_interaction.jobReportFile
 
 # logger
 baseLogger = core_utils.setup_logger('act_monitor')
@@ -19,6 +26,36 @@ class ACTMonitor(PluginBase):
         self.log = core_utils.make_logger(baseLogger, 'aCT submitter', method_name='__init__')
         self.actDB = aCTDBPanda(self.log)
 
+    # get access point
+    def get_access_point(self, workspec, panda_id):
+        if workspec.mapType == WorkSpec.MT_MultiJobs:
+            accessPoint = os.path.join(workspec.get_access_point(), str(panda_id))
+        else:
+            accessPoint = workspec.get_access_point()
+        return accessPoint
+
+    # Check for pilot errors
+    def check_pilot_status(self, workspec, tmpLog):
+        for pandaID in workspec.pandaid_list:
+            # look for job report
+            accessPoint = self.get_access_point(workspec, pandaID)
+            jsonFilePath = os.path.join(accessPoint, jsonJobReport)
+            tmpLog.debug('looking for job report file {0}'.format(jsonFilePath))
+            try:
+                with open(jsonFilePath) as jsonFile:
+                    jobreport = json.load(jsonFile)
+            except:
+                tmpLog.error('failed to load {0}'.format(jsonFilePath))
+                return WorkSpec.ST_failed
+            tmpLog.debug("pilot info for {0}: {1}".format(pandaID, jobreport))
+            # Check for pilot errors
+            if jobreport.get('pilotErrorCode', 0):
+                workspec.set_pilot_error(jobreport.get('pilotErrorCode'), jobreport.get('pilotErrorDiag', ''))
+                return WorkSpec.ST_failed
+            if jobreport.get('exeErrorCode', 0):
+                workspec.set_pilot_error(jobreport.get('exeErrorCode'), jobreport.get('exeErrorDiag', ''))
+                return WorkSpec.ST_failed
+        return WorkSpec.ST_finished
 
     # check workers
     def check_workers(self, workspec_list):
@@ -48,13 +85,16 @@ class ACTMonitor(PluginBase):
             if actstatus in ['sent', 'starting']:
                 newStatus = WorkSpec.ST_submitted
             elif actstatus == 'done':
-                newStatus = WorkSpec.ST_finished
+                newStatus = self.check_pilot_status(workSpec, tmpLog)
             elif actstatus == 'donefailed':
                 newStatus = WorkSpec.ST_failed
             elif actstatus == 'donecancelled':
                 newStatus = WorkSpec.ST_cancelled
 
-            tmpLog.debug('batchStatus {0} -> workerStatus {1}'.format(actstatus, newStatus))
+            if newStatus != workSpec.status:
+                tmpLog.info('ID {0} updated status {1} -> {2} ({3})'.format(workSpec.batchID, workSpec.status, newStatus, actstatus))
+            else:
+                tmpLog.debug('batchStatus {0} -> workerStatus {1}'.format(actstatus, newStatus))
 
             if actjobs[0]['computingElement']:
                 workSpec.computingElement = actjobs[0]['computingElement']


### PR DESCRIPTION
If batch job successfully finished, check pilot job report for internal failures and report back to harvester.