### PR TITLE
fix status reporting for truepilot jobs

### DIFF
--- a/pandaharvester/harvestermonitor/act_monitor.py
+++ b/pandaharvester/harvestermonitor/act_monitor.py
@@ -45,8 +45,10 @@ class ACTMonitor(PluginBase):
                 with open(jsonFilePath) as jsonFile:
                     jobreport = json.load(jsonFile)
             except:
-                tmpLog.error('failed to load {0}'.format(jsonFilePath))
-                return WorkSpec.ST_failed
+                # Assume no job report avaiable means true pilot or push mode
+                # If job report is not available in full push mode aCT would have failed the job
+                tmpLog.debug('no job report at {0}'.format(jsonFilePath))
+                return WorkSpec.ST_finished
             tmpLog.debug("pilot info for {0}: {1}".format(pandaID, jobreport))
             # Check for pilot errors
             if jobreport.get('pilotErrorCode', 0):

--- a/pandaharvester/harvestermonitor/act_monitor.py
+++ b/pandaharvester/harvestermonitor/act_monitor.py
@@ -45,7 +45,7 @@ class ACTMonitor(PluginBase):
                 with open(jsonFilePath) as jsonFile:
                     jobreport = json.load(jsonFile)
             except:
-                # Assume no job report avaiable means true pilot or push mode
+                # Assume no job report available means true pilot or push mode
                 # If job report is not available in full push mode aCT would have failed the job
                 tmpLog.debug('no job report at {0}'.format(jsonFilePath))
                 return WorkSpec.ST_finished


### PR DESCRIPTION
Fixes a problem with yesterday's change, where the monitor would report failed if the job report didn't exist. This led to all truepilot jobs (where there is no job report) being marked failed in harvester. This change ignores a missing job report for truepilot jobs.