### PR TITLE
allow restricting queues to a certain pilot version

### DIFF
--- a/pandaharvester/harvestercore/queue_config_mapper.py
+++ b/pandaharvester/harvestercore/queue_config_mapper.py
@@ -13,6 +13,7 @@ except ImportError:
     JSONDecodeError = ValueError
 
 from pandaharvester.harvesterconfig import harvester_config
+from pandaharvester.harvestermisc.info_utils import PandaQueuesDict
 from .work_spec import WorkSpec
 from .panda_queue_spec import PandaQueueSpec
 from . import core_utils
@@ -258,6 +259,7 @@ class QueueConfigMapper(six.with_metaclass(SingletonWithID, object)):
             allQueuesNameList = set()
             getQueuesDynamic = False
             invalidQueueList = set()
+            pandaQueueDict = PandaQueuesDict()
             # get resolver
             resolver = self._get_resolver()
             if resolver is None:
@@ -539,6 +541,10 @@ class QueueConfigMapper(six.with_metaclass(SingletonWithID, object)):
                 queueConfig.configID = dumpSpec.configID
                 # ignore offline
                 if queueConfig.queueStatus == 'offline':
+                    continue
+                # filter for pilot version
+                if hasattr(harvester_config.qconf, 'pilotVersion') and \
+                    pandaQueueDict[queueConfig.siteName].get('pilot_version') != str(harvester_config.qconf.pilotVersion):
                     continue
                 if 'ALL' not in harvester_config.qconf.queueList and \
                         'DYNAMIC' not in harvester_config.qconf.queueList and \

--- a/templates/panda_harvester.cfg.rpmnew.template
+++ b/templates/panda_harvester.cfg.rpmnew.template
@@ -181,6 +181,8 @@ resolverClass = PandaQueuesDict
 # enable auto-blacklisting of resolver which returns status='offline' to blacklist the queue
 autoBlacklist = False
 
+# restrict to a certain pilot version (optional)
+pilotVersion = 1
 
 
 


### PR DESCRIPTION
This patch filters the queues that harvester serves by pilot_version in AGIS. It is needed because there are major differences in the way aCT works with pilot 1 and 2, and so both cannot be supported at the same time in a single aCT. Thus during pilot 2 commissioning we need two harvesters serving different queues with different pilot versions.

This patch is probably not the best or cleanest way to do this so I am open to other suggestions.