### PR TITLE
Randomize prodSourceLabel in job_fetcher. k8s: yaml load update

### DIFF
--- a/pandaharvester/commit_timestamp.py
+++ b/pandaharvester/commit_timestamp.py
@@ -1,1 +1,1 @@
-timestamp = "13-06-2019 08:31:03 on contrib_cern (by fahui)"
+timestamp = "13-06-2019 08:48:11 on contrib_cern (by fahui)"

--- a/pandaharvester/commit_timestamp.py
+++ b/pandaharvester/commit_timestamp.py
@@ -1,1 +1,1 @@
-timestamp = "13-06-2019 12:38:30 on contrib_cern (by fahui)"
+timestamp = "13-06-2019 14:03:37 on contrib_cern (by fahui)"

--- a/pandaharvester/commit_timestamp.py
+++ b/pandaharvester/commit_timestamp.py
@@ -1,1 +1,1 @@
-timestamp = "11-06-2019 13:02:37 on contrib_cern (by fahui)"
+timestamp = "13-06-2019 08:31:03 on contrib_cern (by fahui)"

--- a/pandaharvester/harvesterbody/job_fetcher.py
+++ b/pandaharvester/harvesterbody/job_fetcher.py
@@ -1,5 +1,6 @@
 import socket
 import datetime
+import random
 from future.utils import iteritems
 
 from pandaharvester.harvesterconfig import harvester_config
@@ -45,11 +46,15 @@ class JobFetcher(AgentBase):
                 if nJobs > harvester_config.jobfetcher.maxJobs:
                     nJobs = harvester_config.jobfetcher.maxJobs
                 # get jobs
-                tmpLog.debug('getting {0} jobs'.format(nJobs))
+                default_prodSourceLabel = queueConfig.get_source_label()
+                pdpm = getattr(queueConfig, 'prodSourceLabelRandomWeightsPermille', {})
+                choice_list = core_utils.make_choice_list(pdpm=pdpm, default=default_prodSourceLabel)
+                prodSourceLabel = random.choice(choice_list)
+                tmpLog.debug('getting {0} jobs for prodSourceLabel {1}'.format(nJobs, prodSourceLabel))
                 sw = core_utils.get_stopwatch()
                 siteName = queueConfig.siteName
                 jobs, errStr = self.communicator.get_jobs(siteName, self.nodeName,
-                                                          queueConfig.get_source_label(),
+                                                          prodSourceLabel,
                                                           self.nodeName, nJobs,
                                                           queueConfig.getJobCriteria)
                 tmpLog.info('got {0} jobs with {1} {2}'.format(len(jobs), errStr, sw.get_elapsed_time()))

--- a/pandaharvester/harvestercore/core_utils.py
+++ b/pandaharvester/harvestercore/core_utils.py
@@ -124,7 +124,7 @@ class SingletonWithThreadAndID(type):
     def __init__(cls, *args,**kwargs):
         cls.__instance = {}
         super(SingletonWithThreadAndID, cls).__init__(*args, **kwargs)
-        
+
     @synchronize
     def __call__(cls, *args, **kwargs):
         thread_id = get_ident()
@@ -605,3 +605,19 @@ class DictTupleHybrid(tuple):
 
     def _asdict(self):
         return dict(zip(self.attributes, self))
+
+
+# Make a list of choice candidates accroding to permille weight
+def make_choice_list(pdpm={}, default=None):
+    weight_sum = sum(pdpm.values())
+    weight_defualt = 1000
+    ret_list = []
+    for candidate, weight in iteritems(pdpm):
+        if weight_sum > 1000:
+            real_weight = int(weight * 1000 / weight_sum)
+        else:
+            real_weight = int(weight)
+        ret_list.extend([candidate]*real_weight)
+        weight_defualt -= real_weight
+    ret_list.extend([default]*weight_defualt)
+    return ret_list

--- a/pandaharvester/harvestercore/job_spec.py
+++ b/pandaharvester/harvestercore/job_spec.py
@@ -531,6 +531,8 @@ class JobSpec(SpecBase):
             return None
         if self.jobParams['prodSourceLabel'] == 'rc_test':
             return 'RC'
+        elif self.jobParams['prodSourceLabel'] == 'rc_test2':
+            return 'RC'
         elif self.jobParams['prodSourceLabel'] == 'rc_alrb':
             return 'ALRB'
         elif self.jobParams['prodSourceLabel'] == 'ptest':

--- a/pandaharvester/harvestermisc/k8s_utils.py
+++ b/pandaharvester/harvestermisc/k8s_utils.py
@@ -25,7 +25,7 @@ class k8s_Client(object):
 
     def read_yaml_file(self, yaml_file):
         with open(yaml_file) as f:
-            yaml_content = yaml.load(f)
+            yaml_content = yaml.load(f, Loader=yaml.FullLoader)
 
         return yaml_content
 

--- a/pandaharvester/harvesterworkermaker/simple_worker_maker.py
+++ b/pandaharvester/harvesterworkermaker/simple_worker_maker.py
@@ -23,20 +23,8 @@ class SimpleWorkerMaker(BaseWorkerMaker):
         except AttributeError:
             self.pilotTypeRandomWeightsPermille = {}
         finally:
-            # randomize pilot type with weighting
-            weight_rc = self.pilotTypeRandomWeightsPermille.get('RC', 0)
-            weight_alrb = self.pilotTypeRandomWeightsPermille.get('ALRB', 0)
-            weight_pt = self.pilotTypeRandomWeightsPermille.get('PT', 0)
-            weight_tmp_sum = weight_rc + weight_alrb + weight_pt
-            if weight_tmp_sum > 1000:
-                weight_rc = weight_rc*1000/weight_tmp_sum
-                weight_alrb = weight_alrb*1000/weight_tmp_sum
-                weight_pt = weight_pt*1000/weight_tmp_sum
-            weight_pr = 1000 - (weight_rc + weight_alrb + weight_pt)
-            self.pilotTypeRandomList = ['PR'] * weight_pr \
-                + ['RC'] * weight_rc \
-                + ['ALRB'] * weight_alrb \
-                + ['PT'] * weight_pt
+            self.pilotTypeRandomList = core_utils.make_choice_list(
+                                            pdpm=self.pilotTypeRandomWeightsPermille, default='PR')
 
     def get_job_core_and_memory(self, queue_dict, job_spec):
 

--- a/pandaharvester/panda_pkg_info.py
+++ b/pandaharvester/panda_pkg_info.py
@@ -1,1 +1,1 @@
-release_version = "0.1.3-rc"
+release_version = "0.1.4-rc"


### PR DESCRIPTION
Here both job_fetcher (in push) and simple_worker_maker (in pull only) take the information from prodSourceLabelRandomWeightsPermille in queueconfig.

For simplicity in config, only prodsourcelabel is in the key (hard set tuple as key in json) of the weight. E.g.
`"prodSourceLabelRandomWeightsPermille": {"rc_test":10, "rc_test2":10, "rc_alrb":10, "ptest":10}`
should cover both pilot 1 and 2 if small percentage of empty pilot is allowed.

For now I still leave the pilotType and pilot version_tag (and piloturl stuff) be handled in submitter plugin (can change after pilot improves and fully migrated to pilot 2), so the core functions remain simpler.