### PR TITLE
Fix bug with changing workflow of queue from push to pull

### DIFF
--- a/pandaharvester/commit_timestamp.py
+++ b/pandaharvester/commit_timestamp.py
@@ -1,1 +1,1 @@
-timestamp = "26-06-2019 15:48:27 on master (by tmaeno)"
+timestamp = "27-06-2019 02:47:47 on contrib_cern (by fahui)"

--- a/pandaharvester/harvestercore/queue_config_mapper.py
+++ b/pandaharvester/harvestercore/queue_config_mapper.py
@@ -473,12 +473,11 @@ class QueueConfigMapper(six.with_metaclass(SingletonWithID, object)):
                         queueConfig.getJobCriteria = None
                     else:
                         queueConfig.getJobCriteria = tmpCriteria
-                # removal of some attributes based on mapType
+                # nullify job attributes if NoJob mapType
                 if queueConfig.mapType == WorkSpec.MT_NoJob:
                     for attName in ['nQueueLimitJob', 'nQueueLimitJobRatio',
                                     'nQueueLimitJobMax', 'nQueueLimitJobMin']:
-                        if hasattr(queueConfig, attName):
-                            delattr(queueConfig, attName)
+                        setattr(queueConfig, attName, None)
                 # heartbeat suppression
                 if queueConfig.truePilot and queueConfig.noHeartbeat == '':
                     queueConfig.noHeartbeat = 'running,transferring,finished,failed'

--- a/pandaharvester/harvestersubmitter/htcondor_submitter.py
+++ b/pandaharvester/harvestersubmitter/htcondor_submitter.py
@@ -294,7 +294,7 @@ def submit_bag_of_workers(data_list):
                 batch_stderr = _condor_macro_replace(batch_log_dict['batch_stderr'], ClusterId=clusterid, ProcId=procid)
                 try:
                     batch_jdl = '{0}.jdl'.format(batch_stderr[:-4])
-                except:
+                except Exception:
                     batch_jdl = None
                 workspec.set_log_file('batch_log', batch_log)
                 workspec.set_log_file('stdout', batch_stdout)


### PR DESCRIPTION
The bug was: when changing mapType (from OneToOne) to NoJob in queueconfig, the nQueueLimitJob and job related attributes in DB pq_table still remained non-zero value so that harvester kept fetching jobs of the queue even with NoJob mapType.